### PR TITLE
fix: remove Bugsnag config section causing FileNotFoundException on WinGet

### DIFF
--- a/EarTrumpet/App.config
+++ b/EarTrumpet/App.config
@@ -1,9 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <configSections>
-		<section name="bugsnag" type="Bugsnag.ConfigurationSection.Configuration, Bugsnag.ConfigurationSection" />
-    </configSections>
-    <bugsnag apiKey="{bugsnag.apikey}" />
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
     </startup>


### PR DESCRIPTION
The app.config still referenced the Bugsnag.ConfigurationSection assembly
which isn't present in WinGet portable installations. This caused a
System.IO.FileNotFoundException at startup when .NET tried to load
the configuration section handler.

Removes the unused configSections and bugsnag elements since Bugsnag
telemetry was already disabled in the code.