### PR TITLE
Fix tray toggle intermittently reopening flyout after close

### DIFF
--- a/EarTrumpet/UI/ViewModels/FlyoutViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/FlyoutViewModel.cs
@@ -101,6 +101,10 @@ private readonly Action _returnFocusToTray;
         // flyout first deactivates it (closing it), then delivers the click — without this
         // guard that trailing click re-opens the flyout. Used to absorb that click.
         private DateTime _lastDeactivatedAt = DateTime.MinValue;
+        // Timestamp of the last transition to Open. Guards against a spurious deactivation
+        // arriving within the window right after opening, which would immediately close the
+        // flyout that just opened.
+        private DateTime _lastOpenedAt = DateTime.MinValue;
         private MouseHook _mh;
         private Rect _winRect;
 
@@ -405,6 +409,7 @@ private readonly Action _returnFocusToTray;
             switch (State)
             {
                 case FlyoutViewState.Open:
+                    _lastOpenedAt = DateTime.UtcNow;
                     _mainViewModel.OnTrayFlyoutShown();
 
                     if (_closedDuringOpen)
@@ -538,7 +543,6 @@ private readonly Action _returnFocusToTray;
             // click would re-open the just-closed flyout. If the click lands right after a
             // deactivation, treat it as the dismiss and absorb it. Keyboard reopen is unaffected.
             if (inputType == InputType.Mouse
-                && (State == FlyoutViewState.Closing_Stage1 || State == FlyoutViewState.Closing_Stage2)
                 && (DateTime.UtcNow - _lastDeactivatedAt) < TimeSpan.FromMilliseconds(300))
             {
                 return;
@@ -572,6 +576,10 @@ private readonly Action _returnFocusToTray;
                 return;
             }
             if (IsPinned)
+            {
+                return;
+            }
+            if ((DateTime.UtcNow - _lastOpenedAt) < TimeSpan.FromMilliseconds(200))
             {
                 return;
             }


### PR DESCRIPTION
## How to Reproduce:

Clicking the tray icon to close an already-open flyout would sometimes reopen it instead of closing it — intermittent, reproducible with any gap between clicks, not just fast double-clicks.

## Root cause:

A single tray click produces two independently-timed signals — OnDeactivated (closes via light-dismiss) and OpenFlyout via PrimaryInvoke (the toggle). The existing 300ms absorb-guard in OpenFlyout also required State == Closing_Stage1/Closing_Stage2, but the close animation can finish (state → Hidden) before the trailing click message arrives — so the state check missed even though the click was well inside the 300ms window, and the click fell through to reopen the flyout.

## Fix: 

Removed the State == condition from the guard; it now absorbs any mouse-triggered OpenFlyout within 300ms of the last deactivation regardless of what state the flyout has already settled into. Also added a companion _lastOpenedAt-based 200ms settling guard on OnDeactivated, to prevent a spurious deactivation immediately after opening (layout/focus side effects of the device list) from closing the flyout before the user has interacted with it.

    if (inputType == InputType.Mouse
        && (State == FlyoutViewState.Closing_Stage1 || State == FlyoutViewState.Closing_Stage2)
        && (DateTime.UtcNow - _lastDeactivatedAt) < TimeSpan.FromMilliseconds(300))
    becomes:
    if (inputType == InputType.Mouse
        && (DateTime.UtcNow - _lastDeactivatedAt) < TimeSpan.FromMilliseconds(300))

Tradeoff (deliberate, not an oversight): absorbing is now unconditional on state, so a genuine close-then-immediately-reopen click within 300ms of the same deactivation is treated as noise from that click, not a fresh intent to reopen. This is a narrow, intentional window — flagging it so it doesn't read as a bug if tested directly.

An earlier, more conservative debounce (_lastMouseInvokeAt, a blanket 250ms cooldown on all mouse-triggered opens) was tried first, before the underlying timing race was fully understood. It was superseded by the precise _lastDeactivatedAt-based fix above, which targets the same race directly rather than debouncing all rapid invokes regardless of cause.

Verification: Tested repeated open/close cycles with both slow (1–10s gaps) and rapid clicking; toggle closed reliably in every case after the fix.

Related: there's an open feature-request discussion for a balance slider (xammen/BetterTrumpet#18) that this fork also implements — happy to open that as a separate PR if there's interest, but this is an unrelated bug fix and stands on its own regardless.

File changed: EarTrumpet/UI/ViewModels/FlyoutViewModel.cs