### PR TITLE
Fix app-row sliders showing default grey color on first launch

### DIFF
--- a/EarTrumpet/UI/Controls/VolumeSlider.cs
+++ b/EarTrumpet/UI/Controls/VolumeSlider.cs
@@ -147,7 +147,7 @@ namespace EarTrumpet.UI.Controls
             ApplyPeakMeterStyle();
             
             // Apply custom colors if enabled
-            ApplyCustomColors();
+            Dispatcher.BeginInvoke(new Action(ApplyCustomColors), System.Windows.Threading.DispatcherPriority.Loaded);
             
             // Subscribe to settings changes for live preview
             if (App.Settings != null)


### PR DESCRIPTION
On first launch, before any theme change occurs, one or more sliders in the mixer flyout can render in grey instead of the configured custom accent color — self-correcting the moment any theme change happens. Confirmed on a clean install with no prior settings.

Root cause: VolumeSlider.ApplyCustomColors() is called twice, in two different ways. On theme change (OnThemeChangedReapplyColors), it's correctly deferred via Dispatcher.BeginInvoke(new Action(ApplyCustomColors), DispatcherPriority.Loaded). On initial control load (OnLoaded), it's called synchronously, immediately.

The app's own Theme:Brush system sets colors via a local value at a higher priority than a plain property assignment, and runs its own pass after Loaded. On initial load, the synchronous call wins the assignment first, then gets silently overwritten moments later by the theme system's deferred pass — leaving the affected slider(s) grey until a theme change re-triggers the correctly-deferred path. Since this is a timing race, which specific slider(s) lose it can vary by machine/session — the fix corrects the race generically for any VolumeSlider instance, not one specific row.

Fix: Defer the initial-load call the same way the theme-change path already does.

    ApplyCustomColors();
    becomes:
    Dispatcher.BeginInvoke(new Action(ApplyCustomColors), System.Windows.Threading.DispatcherPriority.Loaded);

Verification: Reproduced on a clean install (no prior settings/config) with custom slider colors enabled — confirmed present on stock, unmodified upstream. Restarted the app multiple times post-fix; sliders show correct custom colors immediately on first flyout open, no theme change required.

File changed: EarTrumpet/UI/Controls/VolumeSlider.cs