### PR TITLE
Fix: keyboard focus adorner persists around device card after keypress

### DIFF
--- a/EarTrumpet/UI/Views/DeviceView.xaml
+++ b/EarTrumpet/UI/Views/DeviceView.xaml
@@ -15,7 +15,8 @@
 
         <ListViewItem Name="DeviceListItem"
                       AutomationProperties.Name="{Binding Device.AccessibleName}"
-                      Tag="{x:Static views:DeviceView.DeviceListItemKey}">
+                      Tag="{x:Static views:DeviceView.DeviceListItemKey}"
+                      FocusVisualStyle="{x:Null}">
             <Border Theme:Brush.Background=":=Transparent, Flyout:FlyoutBackground, Flyout:HighContrast=Window" Theme:Brush.BorderBrush="Theme=Transparent, HighContrast=Text">
                 <Border.Style>
                     <Style TargetType="Border">


### PR DESCRIPTION
# Issue: keyboard focus adorner persists around device card after keypress

## How to Reproduce:

1. Open the flyout.
2. Press any key — even one the app doesn't act on (e.g. `R`).
3. Close the flyout (any method: click away, Escape, tray icon).
4. Reopen the flyout.
5. A colored focus-ring border (WPF's default `FocusVisualAdorner`) appears wrapped around the entire master device card — icon, name, master volume slider, all of it.

Reproduces identically on stock upstream with zero fork code present, confirmed before any fix was applied — this is a pre-existing upstream bug, not fork-specific.

## Root cause

Two things compound:

1. **The existing removal runs one cycle too early.** `FlyoutWindow` already calls `FocusAndRemoveFocusVisual()` → `RemoveFocusVisual()` on open and on `Closing_Stage1`, which walks the adorner layer and removes any `FocusVisualAdorner` it finds. But WPF creates that adorner *asynchronously*, after this synchronous check has already finished. So the removal fires, finds nothing, and the adorner shows up anyway — one open/close cycle later than the check that was supposed to catch it.

2. **The mitigation is self-sustaining.** Once a real keypress has occurred anywhere in the session, WPF's internal "show keyboard focus cues" state stays latched on. From that point forward, *any* programmatic `.Focus()` call — including the existing mitigation's own defensive call inside `FocusAndRemoveFocusVisual()` — redraws the adorner again, asynchronously, regardless of whether the user pressed a key that specific cycle. It's not a one-off timing race; the fix's own re-focus call keeps regenerating the thing it's trying to suppress.

This also explains why the bug only follows keyboard input, and why it clears on any button click (mute button, `BalanceSlider` mute/reset) but not a slider drag: a `Button` click moves keyboard focus off `DeviceListItem` entirely, leaving nothing for the adorner to attach to, while a `Slider` thumb drag never calls `.Focus()`, so focus — and the adorner — stays put.

## Fix

Single line: add `FocusVisualStyle="{x:Null}"` to `DeviceListItem` in `DeviceView.xaml`. This tells WPF to never create a focus-visual adorner for this element in the first place, instead of continuing to chase its removal timing. `FocusVisualStyle="{x:Null}"` only suppresses the visual adorner — it doesn't disable focus or keyboard input handling.

The existing `FocusAndRemoveFocusVisual` / `RemoveFocusVisual` methods in `DeviceView.xaml.cs` are left untouched — now redundant (there's nothing left for them to find), but harmless, and out of scope for this change.

## Verification

- Repro steps above no longer produce the border, with the fix applied.
- Keyboard-navigation regression check: arrow keys still adjust volume, `Space` still opens the popup, `M` and `.` still toggle mute — all confirmed working correctly with the fix in place, no regressions found.