### PR TITLE
Fix peak meter vertical off-center for single-bar styles

### DIFF
--- a/EarTrumpet/UI/Controls/VolumeSlider.cs
+++ b/EarTrumpet/UI/Controls/VolumeSlider.cs
@@ -280,7 +280,7 @@ namespace EarTrumpet.UI.Controls
                 case PeakMeterStyle.Dotted:
                     // Dotted: small squares with tiny gaps, punchy and visible
                     _peakMeter1.Height = 3;
-                    _peakMeter1.Margin = new Thickness(0, -2, 0, 0);
+                    _peakMeter1.Margin = new Thickness(0);
                     _peakMeter1.CornerRadius = new CornerRadius(0);
                     _peakMeter1.Opacity = 0.7;
                     _peakMeter1.Visibility = Visibility.Visible;
@@ -291,7 +291,7 @@ namespace EarTrumpet.UI.Controls
                 case PeakMeterStyle.Blocks:
                     // Blocks: wide chunky segments, LED meter style
                     _peakMeter1.Height = 4;
-                    _peakMeter1.Margin = new Thickness(0, -2, 0, 0);
+                    _peakMeter1.Margin = new Thickness(0);
                     _peakMeter1.CornerRadius = new CornerRadius(0);
                     _peakMeter1.Opacity = 0.7;
                     _peakMeter1.Visibility = Visibility.Visible;
@@ -302,7 +302,7 @@ namespace EarTrumpet.UI.Controls
                 case PeakMeterStyle.Bars:
                     // Line: single clean thin bar, no pattern
                     _peakMeter1.Height = 2;
-                    _peakMeter1.Margin = new Thickness(0, -1, 0, 0);
+                    _peakMeter1.Margin = new Thickness(0);
                     _peakMeter1.CornerRadius = new CornerRadius(1);
                     _peakMeter1.Opacity = 0.55;
                     _peakMeter1.Visibility = Visibility.Visible;
@@ -313,7 +313,7 @@ namespace EarTrumpet.UI.Controls
                 case PeakMeterStyle.Wave:
                     // Dashes: wide spaced dashes, retro feel
                     _peakMeter1.Height = 3;
-                    _peakMeter1.Margin = new Thickness(0, -2, 0, 0);
+                    _peakMeter1.Margin = new Thickness(0);
                     _peakMeter1.CornerRadius = new CornerRadius(1);
                     _peakMeter1.Opacity = 0.65;
                     _peakMeter1.Visibility = Visibility.Visible;


### PR DESCRIPTION
## How to Reproduce:
Set Peak Meter Style to Dotted, Blocks, Bars, or Wave (Settings → Appearance) and play any audio. The peak meter bar sits visibly above the slider track's center instead of on it.

## Root cause:
Classic style shows two bars straddling the track center: PeakMeter1 offset slightly up, PeakMeter2 offset slightly down. Dotted/Blocks/Bars/Wave hide PeakMeter2 and show only PeakMeter1 — but PeakMeter1 kept the same negative top margin that only made sense when paired with a second bar below it. With nothing below it, that single bar renders off-center.

## Fix:
Zero the margin for the four single-bar styles so the one visible bar sits on the track's actual center. Classic is untouched (still needs its offset since it genuinely has two bars).