### PR TITLE
Add toggle to disable global text-color theming, keep sliders-only

### DIFF
--- a/EarTrumpet/AppSettings.cs
+++ b/EarTrumpet/AppSettings.cs
@@ -1210,6 +1210,20 @@ namespace EarTrumpet
             }
         }
 
+        // Whether the theme's TextColor should override menu/window text globally (tray
+        // menu, settings, flyout labels) in addition to the sliders. Off by default -
+        // most themes pick a TextColor tuned for the flyout's tinted background, and it
+        // reads as too strong against the plain menu/window chrome elsewhere.
+        public bool ApplyThemeTextColor
+        {
+            get => _settings.Get("ApplyThemeTextColor", false);
+            set
+            {
+                _settings.Set("ApplyThemeTextColor", value);
+                if (!_batchMode) CustomSliderColorsChanged?.Invoke();
+            }
+        }
+
         // Volume profiles JSON storage
         public string VolumeProfilesJson
         {

--- a/EarTrumpet/UI/ViewModels/EarTrumpetColorsSettingsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetColorsSettingsPageViewModel.cs
@@ -155,6 +155,19 @@ namespace EarTrumpet.UI.ViewModels
             }
         }
 
+        // Whether the theme's text color applies globally (tray menu, settings, flyout
+        // labels) in addition to the sliders. Off by default - see AppSettings.
+        public bool ApplyThemeTextColor
+        {
+            get => _settings.ApplyThemeTextColor;
+            set
+            {
+                _settings.ApplyThemeTextColor = value;
+                RaisePropertyChanged(nameof(ApplyThemeTextColor));
+                ApplyExtendedThemeColors();
+            }
+        }
+
         // Dynamic album art theme
         public bool UseDynamicAlbumArtTheme
         {
@@ -854,7 +867,7 @@ namespace EarTrumpet.UI.ViewModels
                 var accentGlow = _settings.AccentGlowColor;
 
                 bool hasWindowBg = windowBg != Colors.Transparent;
-                bool hasTextColor = textColor != Colors.Transparent;
+                bool hasTextColor = textColor != Colors.Transparent && _settings.ApplyThemeTextColor;
 
                 if (!hasWindowBg && !hasTextColor)
                 {
@@ -883,6 +896,14 @@ namespace EarTrumpet.UI.ViewModels
                         grayTextRef.Value = $"#{grayVersion.A:X2}{grayVersion.R:X2}{grayVersion.G:X2}{grayVersion.B:X2}";
                         grayTextRef.Rules.Clear();
                     }
+                }
+                else if (_refsBackedUp)
+                {
+                    // Text color is set but ApplyThemeTextColor is off (or the theme has no
+                    // text color) - make sure Text/GrayText aren't left holding a stale
+                    // override from a previous ApplyExtendedThemeColors call.
+                    RestoreThemeRef("Text");
+                    RestoreThemeRef("GrayText");
                 }
 
                 if (hasWindowBg)
@@ -986,6 +1007,25 @@ namespace EarTrumpet.UI.ViewModels
             catch (Exception ex)
             {
                 Trace.WriteLine($"EarTrumpetColorsSettingsPageViewModel: RestoreOriginalThemeRefs failed - {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Restore a single Ref's original value/rules, leaving the rest of the backed-up
+        /// Refs (e.g. window background) untouched.
+        /// </summary>
+        private void RestoreThemeRef(string key)
+        {
+            if (!_originalRefs.TryGetValue(key, out var backupObj) || !(backupObj is RefBackup backup)) return;
+
+            var r = Manager.Current.References.FirstOrDefault(x => x.Key == key);
+            if (r == null) return;
+
+            r.Value = backup.Value;
+            r.Rules.Clear();
+            foreach (var rule in backup.Rules)
+            {
+                r.Rules.Add(rule);
             }
         }
 

--- a/EarTrumpet/UI/Views/SettingsWindow.xaml
+++ b/EarTrumpet/UI/Views/SettingsWindow.xaml
@@ -697,6 +697,34 @@
                     </Border>
 
                     <!-- ═══════════════════════════════════════════════════ -->
+                    <!-- Apply text color globally (menus/windows, not just sliders) -->
+                    <!-- Always visible regardless of Dynamic/Presets/Custom tab,   -->
+                    <!-- since TextColor is set by all three paths.                 -->
+                    <!-- ═══════════════════════════════════════════════════ -->
+                    <Border Margin="0,0,0,16" Padding="16,12" CornerRadius="10"
+                            Theme:Brush.Background="Theme={Theme}ListLow, HighContrast=Window">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Border Grid.Column="0" Style="{StaticResource SectionIconBorder}">
+                                <TextBlock Text="&#xE8D2;" FontFamily="Segoe MDL2 Assets" FontSize="18"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           Foreground="White" />
+                            </Border>
+                            <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                <TextBlock Text="Custom Text Colour" FontSize="15" FontWeight="SemiBold" />
+                                <TextBlock Text="Also apply theme to menu text"
+                                           Style="{StaticResource BodySubText}" FontSize="12" TextWrapping="Wrap" />
+                            </StackPanel>
+                            <CheckBox Grid.Column="2" VerticalAlignment="Center"
+                                      IsChecked="{Binding ApplyThemeTextColor, Mode=TwoWay}" />
+                        </Grid>
+                    </Border>
+
+                    <!-- ═══════════════════════════════════════════════════ -->
                     <!-- SEGMENTED TAB BAR: [Dynamic] [Presets] [Custom]     -->
                     <!-- ═══════════════════════════════════════════════════ -->
                     <Border Margin="0,0,0,16" CornerRadius="8" Padding="3"


### PR DESCRIPTION
## Issue
The extended-colors feature (Settings → Appearance → Colors) applies the active theme's TextColor to the app-wide Text/GrayText refs — tray menu, settings window, everywhere — not just sliders, with no way to opt out. Every built-in preset bundles a TextColor tuned for the flyout's tinted background, so simply picking a preset always recolors the tray menu too, which reads as too strong against the plain menu/window chrome elsewhere.

## Fix
Adds `ApplyThemeTextColor` (default off) as its own toggle in Settings. Slider and window-background theming keep working exactly as before; menu/window text only gets the theme's color if this is explicitly turned on.