### PR TITLE
Fix settings window grey flash during resize with custom colors

### DIFF
--- a/EarTrumpet/UI/ViewModels/EarTrumpetColorsSettingsPageViewModel.cs
+++ b/EarTrumpet/UI/ViewModels/EarTrumpetColorsSettingsPageViewModel.cs
@@ -927,6 +927,31 @@ namespace EarTrumpet.UI.ViewModels
                         acrylicFallbackRef.Value = bgHex;
                         acrylicFallbackRef.Rules.Clear();
                     }
+
+                    // Override AcrylicBackground - the settings window's left nav pane
+                    // (Grid.Column 0) uses this ref directly for its normal resting-state
+                    // background. Without this override it stays on the theme's own
+                    // un-tinted default, which is what shows through as a plain grey flash
+                    // during a live resize (the real acrylic backdrop briefly suppresses
+                    // and this Border becomes momentarily visible) and disappears again
+                    // once the window settles.
+                    var acrylicBackgroundRef = refs.FirstOrDefault(r => r.Key == "AcrylicBackground");
+                    if (acrylicBackgroundRef != null)
+                    {
+                        acrylicBackgroundRef.Value = bgHex;
+                        acrylicBackgroundRef.Rules.Clear();
+                    }
+
+                    // Override AcrylicColor_Settings - the settings window's actual DWM
+                    // backdrop brush (Theme:AcrylicBrush.Background on the window root),
+                    // a separate system from the WPF Border layers above. Same "/opacity"
+                    // tint format as AcrylicColor_Flyout.
+                    var acrylicSettingsRef = refs.FirstOrDefault(r => r.Key == "AcrylicColor_Settings");
+                    if (acrylicSettingsRef != null)
+                    {
+                        acrylicSettingsRef.Value = $"{bgHex}/{FlyoutAcrylicTintOpacity}";
+                        acrylicSettingsRef.Rules.Clear();
+                    }
                 }
 
                 // Fire theme change to repaint all UI elements
@@ -945,7 +970,7 @@ namespace EarTrumpet.UI.ViewModels
         {
             if (_refsBackedUp) return;
 
-            var keysToBackup = new[] { "Text", "GrayText", "Background", "FlyoutBackground", "PopupBackground", "AcrylicColor_Flyout", "AcrylicBackgroundFallback" };
+            var keysToBackup = new[] { "Text", "GrayText", "Background", "FlyoutBackground", "PopupBackground", "AcrylicColor_Flyout", "AcrylicBackgroundFallback", "AcrylicColor_Settings", "AcrylicBackground" };
             foreach (var key in keysToBackup)
             {
                 var r = Manager.Current.References.FirstOrDefault(x => x.Key == key);


### PR DESCRIPTION
## How to Reproduce:
Enable Custom Colors with a non-default window background, open Settings, resize the window. The left nav pane briefly flashes plain grey during the resize before settling back to the correct tinted color.

## Root cause:
The extended-colors override list covers `Background`, `AcrylicColor_Flyout`, `AcrylicBackgroundFallback`, etc., but misses two refs the settings window's own acrylic layers use for their resting-state background: `AcrylicBackground` (the left nav pane's Border) and `AcrylicColor_Settings` (the window's actual DWM backdrop brush). During a live resize the real acrylic backdrop briefly suppresses, and whichever fallback layer becomes momentarily visible was still on the theme's un-tinted default.

## Fix:
Adds both refs to the same override/backup/restore handling the other Background-family refs already get.